### PR TITLE
Update README with docker group note

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The script will:
 
 After it finishes you can visit the frontend at `http://localhost:3000` and the Strapi admin at `http://localhost:1337`.
 
+If Docker fails with a permission denied error when accessing `/var/run/docker.sock`, open a new terminal session or run `newgrp docker` so your shell picks up the new group membership, then rerun the last command.
+
 ### Manual steps
 
 If you prefer to install everything manually, follow these commands instead of running the script:

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -28,9 +28,9 @@ sudo apt install -y nodejs
 sudo systemctl enable --now docker
 
 # Add current user to the docker group if not already added
-if ! groups $USER | grep -q docker; then
-    sudo usermod -aG docker $USER
-    echo "You may need to log out and log back in for docker group membership to take effect." >&2
+if ! groups "$USER" | grep -q docker; then
+    sudo usermod -aG docker "$USER"
+    echo "You may need to log out and back in or run 'newgrp docker' for group changes to take effect." >&2
 fi
 
 # Install project dependencies


### PR DESCRIPTION
## Summary
- clarify that a new shell or `newgrp docker` is needed after setup to use docker

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686e6c3bb0d88328b8cc4947c4b23039