### PR TITLE
Ensure frontend build before running containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ Both apps are basic starters. The backend exposes a single `Page` content type a
    (cd backend && npm install)
    (cd frontend && npm install)
    ```
-3. Start the stack with Docker Compose:
+3. Build the frontend:
+   ```bash
+   (cd frontend && npm run build)
+   ```
+4. Start the stack with Docker Compose:
    ```bash
    docker compose up --build
    ```
-4. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
+5. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
 
 ## Running tests
 
@@ -96,7 +100,9 @@ cp .env.example .env
 
 # Install dependencies
 (cd backend && npm install)
+
 (cd frontend && npm install)
+(cd frontend && npm run build)
 
 # Start services
 docker compose up --build

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -36,6 +36,7 @@ fi
 # Install project dependencies
 (cd backend && npm install)
 (cd frontend && npm install)
+(cd frontend && npm run build)
 
 # Copy example environment file if .env does not exist
 if [ ! -f .env ]; then


### PR DESCRIPTION
## Summary
- add frontend build step in setup script
- update README with instructions to run `npm run build` before starting Docker

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686e7590f3a8832892b381ced5f53a46