### PR TITLE
Fix initial backend pg install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,17 @@ Both apps are basic starters. The backend exposes a single `Page` content type a
 ## Development
 
 1. Copy `.env.example` to `.env` and adjust values as needed.
-2. Install dependencies:
+2. Install dependencies inside the containers:
    ```bash
-   (cd backend && npm install)
-   (cd frontend && npm install)
+   docker compose run --rm backend npm install
+   docker compose run --rm frontend npm install
+   docker compose run --rm frontend npm run build
    ```
-3. Build the frontend:
-   ```bash
-   (cd frontend && npm run build)
-   ```
-4. Start the stack with Docker Compose:
+3. Start the stack with Docker Compose:
    ```bash
    docker compose up --build
    ```
-5. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
+4. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
 
 ## Running tests
 
@@ -98,11 +95,10 @@ cd unlocked-dashboard
 # Copy environment variables
 cp .env.example .env
 
-# Install dependencies
-(cd backend && npm install)
-
-(cd frontend && npm install)
-(cd frontend && npm run build)
+# Install dependencies inside the containers
+docker compose run --rm backend npm install
+docker compose run --rm frontend npm install
+docker compose run --rm frontend npm run build
 
 # Start services
 docker compose up --build

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -33,10 +33,17 @@ if ! groups "$USER" | grep -q docker; then
     echo "You may need to log out and back in or run 'newgrp docker' for group changes to take effect." >&2
 fi
 
-# Install project dependencies
-(cd backend && npm install)
-(cd frontend && npm install)
-(cd frontend && npm run build)
+# Install project dependencies inside the containers so the
+# named volumes get populated on first run.
+if command -v docker &>/dev/null && docker compose version &>/dev/null; then
+    docker compose run --rm backend npm install
+    docker compose run --rm frontend npm install
+    docker compose run --rm frontend npm run build
+else
+    docker-compose run --rm backend npm install
+    docker-compose run --rm frontend npm install
+    docker-compose run --rm frontend npm run build
+fi
 
 # Copy example environment file if .env does not exist
 if [ ! -f .env ]; then


### PR DESCRIPTION
## Summary
- update setup script to populate node_modules volumes via Docker
- adjust README to use Docker for dependency installs

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686ead52e86c8328bc3478cb9354ada7