### PR TITLE
Auto-install dependencies at container start

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,11 @@ Both apps are basic starters. The backend exposes a single `Page` content type a
 ## Development
 
 1. Copy `.env.example` to `.env` and adjust values as needed.
-2. Install dependencies inside the containers:
-   ```bash
-   docker compose run --rm backend npm install
-   docker compose run --rm frontend npm install
-   docker compose run --rm frontend npm run build
-   ```
-3. Start the stack with Docker Compose:
+2. Start the stack with Docker Compose (dependencies will be installed automatically):
    ```bash
    docker compose up --build
    ```
-4. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
+3. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
 
 ## Running tests
 
@@ -95,12 +89,7 @@ cd unlocked-dashboard
 # Copy environment variables
 cp .env.example .env
 
-# Install dependencies inside the containers
-docker compose run --rm backend npm install
-docker compose run --rm frontend npm install
-docker compose run --rm frontend npm run build
-
-# Start services
+# Start services (dependencies will be installed automatically)
 docker compose up --build
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     volumes:
       - ./backend:/app
       - backend-node-modules:/app/node_modules
+    command: sh -c "npm install && npm run start"
     environment:
       DATABASE_CLIENT: postgres
       DATABASE_HOST: db
@@ -32,6 +33,7 @@ services:
     volumes:
       - ./frontend:/app
       - frontend-node-modules:/app/node_modules
+    command: sh -c "npm install && npm run build && npm start"
     environment:
       BACKEND_URL: http://localhost:1337
     ports:

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -33,17 +33,7 @@ if ! groups "$USER" | grep -q docker; then
     echo "You may need to log out and back in or run 'newgrp docker' for group changes to take effect." >&2
 fi
 
-# Install project dependencies inside the containers so the
-# named volumes get populated on first run.
-if command -v docker &>/dev/null && docker compose version &>/dev/null; then
-    docker compose run --rm backend npm install
-    docker compose run --rm frontend npm install
-    docker compose run --rm frontend npm run build
-else
-    docker-compose run --rm backend npm install
-    docker-compose run --rm frontend npm install
-    docker-compose run --rm frontend npm run build
-fi
+# Dependencies will be installed automatically when the containers start
 
 # Copy example environment file if .env does not exist
 if [ ! -f .env ]; then


### PR DESCRIPTION
## Summary
- automatically run `npm install` during backend container startup
- ensure frontend container builds and starts after installing modules
- simplify README instructions
- remove manual install from setup script

## Testing
- `npm test` in backend
- `npm test` in frontend

------
https://chatgpt.com/codex/tasks/task_b_686eb124bc9c832899a724d68ba389a3