### PR TITLE
Fix Strapi token salt setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Both apps are basic starters. The backend exposes a single `Page` content type a
 
 ## Development
 
-1. Copy `.env.example` to `.env` and adjust values as needed.
+1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS` and `API_TOKEN_SALT`).
 2. Start the stack with Docker Compose (dependencies will be installed automatically):
    ```bash
    docker compose up --build

--- a/backend/config/admin.js
+++ b/backend/config/admin.js
@@ -1,0 +1,5 @@
+module.exports = ({ env }) => ({
+  apiToken: {
+    salt: env('API_TOKEN_SALT'),
+  },
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       DATABASE_PASSWORD: strapi
       DATABASE_SSL: 'false'
       APP_KEYS: change_me
+      API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       CLIENT_URL: http://localhost:3000
     ports:
       - '1337:1337'


### PR DESCRIPTION
## Summary
- specify API_TOKEN_SALT for the backend service
- add Strapi admin config that reads the salt from env
- clarify env variables in README

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_b_686eb3a61be48328a11c054f796d7d38