### PR TITLE
Fix Strapi admin secret configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Both apps are basic starters. The backend exposes a single `Page` content type a
 
 ## Development
 
-1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS` and `API_TOKEN_SALT`).
+1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS`, `ADMIN_JWT_SECRET` and `API_TOKEN_SALT`).
 2. Start the stack with Docker Compose (dependencies will be installed automatically):
    ```bash
    docker compose up --build

--- a/backend/config/admin.js
+++ b/backend/config/admin.js
@@ -1,4 +1,7 @@
 module.exports = ({ env }) => ({
+  auth: {
+    secret: env('ADMIN_JWT_SECRET'),
+  },
   apiToken: {
     salt: env('API_TOKEN_SALT'),
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       DATABASE_PASSWORD: strapi
       DATABASE_SSL: 'false'
       APP_KEYS: change_me
+      ADMIN_JWT_SECRET: changeme
       API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       CLIENT_URL: http://localhost:3000
     ports:


### PR DESCRIPTION
## Summary
- supply `ADMIN_JWT_SECRET` to Strapi admin config
- expose the variable through `docker-compose.yml`
- mention the new env requirement in README

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ebddf27c08328ae8c97a6e9676538