### PR TITLE
Add upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,5 @@ docker compose up --build
 ```
 
 Once the services start you can access the frontend at `http://localhost:3000` and the Strapi admin at `http://localhost:1337`.
+
+For an outline of how to turn this starter into the full-featured monorepo described in the project brief, see [docs/upgrade.md](docs/upgrade.md).

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,33 @@
+# Full Stack Upgrade Guide
+
+This guide outlines the major steps to extend the starter project into the complete monorepo described in the project brief. Each step references official documentation so you can tailor the implementation to your needs.
+
+## 1. Extend the Strapi backend
+
+1. Create additional collection types (Products, Orders, Appointments, Video Calls) using Strapi's Content Type Builder or by editing the JSON schemas under `backend/src/api`.
+2. Configure roles and permissions so that public visitors can read published content while authenticated users can create orders and appointments.
+3. Implement custom controllers or lifecycle hooks for features such as appointment conflict checking and the Stripe webhook for order confirmation.
+4. Enable draft/publish and preview mode by setting `CLIENT_URL` and `PREVIEW_SECRET` in `backend/config/admin.js`.
+5. Seed initial content inside `backend/src/index.js` during the bootstrap phase.
+
+## 2. Build out the Next.js frontend
+
+1. Add pages for `/dashboard`, `/appointments`, `/store` and a dynamic `[slug].js` route. Use `getStaticPaths` and `getStaticProps` to fetch page data from Strapi.
+2. Implement a basic authentication flow that calls Strapi's `/api/auth/local` endpoint and stores the returned JWT.
+3. Integrate Craft.js on the dashboard so editors can design pages visually. Persist the generated JSON to the Strapi `Pages` collection type.
+4. Display products from Strapi on the store page and create an API route (`/api/checkout`) that uses the Stripe SDK to start a Checkout Session.
+5. Add a `/api/preview` route that enables Next.js draft mode when the correct secret is provided.
+
+## 3. Docker and Environment
+
+1. Update `docker-compose.yml` with any new environment variables you introduce for Stripe or video call providers.
+2. Ensure both `backend/Dockerfile` and `frontend/Dockerfile` install dependencies and build the apps in production mode.
+3. Copy `.env.example` to `.env` and fill in strong secrets before running `docker compose up`.
+
+## 4. Deployment on DigitalOcean
+
+1. Edit `.do/app.yaml` so each service exposes the correct environment variables and routes. The example file already shows the structure.
+2. Create a DigitalOcean App via the dashboard or `doctl` and supply the secrets referenced in the spec.
+3. Optionally enable the provided GitHub Actions workflow which runs `doctl apps update` whenever you push to `main`.
+
+This guide does not cover every detail of the final application but provides a high‑level checklist to help you iterate from the starter code. Consult the README and official docs for Next.js, Strapi and DigitalOcean as you expand the project.


### PR DESCRIPTION
## Summary
- document high-level steps to build a full-featured monorepo
- link the new guide from the README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686ed2e89f348328a68863c215506576