### PR TITLE
Implement Step 1 backend upgrades

### DIFF
--- a/backend/config/admin.js
+++ b/backend/config/admin.js
@@ -5,4 +5,8 @@ module.exports = ({ env }) => ({
   apiToken: {
     salt: env('API_TOKEN_SALT'),
   },
+  preview: {
+    clientUrl: env('CLIENT_URL', 'http://localhost:3000'),
+    previewSecret: env('PREVIEW_SECRET', 'supersecret'),
+  },
 });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^5.2.0",
+        "stripe": "^12.18.0",
         "styled-components": "^5.2.1"
       },
       "devDependencies": {
@@ -19250,6 +19251,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "12.18.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-12.18.0.tgz",
+      "integrity": "sha512-cYjgBM2SY/dTm8Lr6eMyyONaHTZHA/QjHxFUIW5WH8FevSRIGAVtXEmBkUXF1fsqe7QvvRgQSGSJZmjDacegGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=8.1.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
       }
     },
     "node_modules/style-loader": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^5.2.0",
+    "stripe": "^12.18.0",
     "styled-components": "^5.2.1"
   },
   "devDependencies": {

--- a/backend/src/api/appointment/content-types/appointment/lifecycles.js
+++ b/backend/src/api/appointment/content-types/appointment/lifecycles.js
@@ -1,0 +1,11 @@
+module.exports = {
+  async beforeCreate(event) {
+    const { data } = event.params;
+    const existing = await strapi.db.query('api::appointment.appointment').findOne({
+      where: { scheduledAt: data.scheduledAt },
+    });
+    if (existing) {
+      throw new Error('Time slot already booked');
+    }
+  },
+};

--- a/backend/src/api/appointment/content-types/appointment/schema.json
+++ b/backend/src/api/appointment/content-types/appointment/schema.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "appointments",
+  "info": {
+    "singularName": "appointment",
+    "pluralName": "appointments",
+    "displayName": "Appointment",
+    "description": "Customer appointments"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": { "type": "string" },
+    "scheduledAt": { "type": "datetime" },
+    "email": { "type": "email" }
+  }
+}

--- a/backend/src/api/order/content-types/order/schema.json
+++ b/backend/src/api/order/content-types/order/schema.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "orders",
+  "info": {
+    "singularName": "order",
+    "pluralName": "orders",
+    "displayName": "Order",
+    "description": "Customer orders"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "orderNumber": { "type": "string" },
+    "products": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::product.product"
+    },
+    "total": { "type": "decimal" }
+  }
+}

--- a/backend/src/api/order/controllers/order.js
+++ b/backend/src/api/order/controllers/order.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
+
+module.exports = {
+  async webhook(ctx) {
+    const sig = ctx.request.headers['stripe-signature'];
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        ctx.request.body,
+        sig,
+        process.env.STRIPE_WEBHOOK_SECRET
+      );
+    } catch (err) {
+      ctx.throw(400, `Webhook Error: ${err.message}`);
+    }
+
+    if (event.type === 'checkout.session.completed') {
+      const session = event.data.object;
+      await strapi.entityService.create('api::order.order', {
+        data: {
+          orderNumber: session.id,
+          total: session.amount_total / 100,
+        },
+      });
+    }
+
+    ctx.body = { received: true };
+  },
+};

--- a/backend/src/api/product/content-types/product/schema.json
+++ b/backend/src/api/product/content-types/product/schema.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "products",
+  "info": {
+    "singularName": "product",
+    "pluralName": "products",
+    "displayName": "Product",
+    "description": "Store products"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": { "type": "string" },
+    "description": { "type": "text" },
+    "price": { "type": "decimal" }
+  }
+}

--- a/backend/src/api/video-call/content-types/video-call/schema.json
+++ b/backend/src/api/video-call/content-types/video-call/schema.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "video_calls",
+  "info": {
+    "singularName": "video-call",
+    "pluralName": "video-calls",
+    "displayName": "Video Call",
+    "description": "Video call sessions"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": { "type": "string" },
+    "meetingUrl": { "type": "string" },
+    "scheduledAt": { "type": "datetime" }
+  }
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,5 +2,45 @@
 
 module.exports = {
   register() {},
-  bootstrap() {},
+  async bootstrap() {
+    const pageCount = await strapi.entityService.count('api::page.page');
+    if (pageCount === 0) {
+      await strapi.entityService.create('api::page.page', {
+        data: {
+          title: 'Home',
+          slug: 'home',
+          content: {},
+        },
+      });
+    }
+
+    const roleService = strapi.plugin('users-permissions').service('role');
+    const publicRole = await roleService.findOne(1);
+    await roleService.updateRole(publicRole.id, {
+      permissions: {
+        ...publicRole.permissions,
+        'api::page.page': {
+          controllers: {
+            page: {
+              find: { enabled: true },
+              findOne: { enabled: true },
+            },
+          },
+        },
+      },
+    });
+
+    const authRole = await roleService.findOne(2);
+    await roleService.updateRole(authRole.id, {
+      permissions: {
+        ...authRole.permissions,
+        'api::order.order': {
+          controllers: { order: { create: { enabled: true } } },
+        },
+        'api::appointment.appointment': {
+          controllers: { appointment: { create: { enabled: true } } },
+        },
+      },
+    });
+  },
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       ADMIN_JWT_SECRET: changeme
       API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       CLIENT_URL: http://localhost:3000
+      PREVIEW_SECRET: someRandomPreviewSecret
     ports:
       - '1337:1337'
     depends_on:


### PR DESCRIPTION
## Summary
- add Product, Order, Appointment and Video Call collection type schemas
- wire up appointment conflict check lifecycle
- add Stripe webhook controller for orders
- seed initial content and set basic permissions
- expose preview config in admin settings
- add `stripe` dependency
- pass `PREVIEW_SECRET` through docker compose

## Testing
- `npm test` (fails: jest not found)
- `npm test` in frontend (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_b_686ed4f33b748328a176e119c5ba5a29