### PR TITLE
Implement upgrade step 2 beginnings

### DIFF
--- a/frontend/__tests__/login.test.js
+++ b/frontend/__tests__/login.test.js
@@ -1,0 +1,8 @@
+import handler from '../pages/api/login';
+import { createMocks } from 'node-mocks-http';
+
+test('rejects non POST requests', async () => {
+  const { req, res } = createMocks({ method: 'GET' });
+  await handler(req, res);
+  expect(res._getStatusCode()).toBe(405);
+});

--- a/frontend/__tests__/preview.test.js
+++ b/frontend/__tests__/preview.test.js
@@ -1,0 +1,8 @@
+import handler from '../pages/api/preview';
+import { createMocks } from 'node-mocks-http';
+
+test('rejects invalid secret', async () => {
+  const { req, res } = createMocks({ method: 'GET', query: { secret: 'bad', slug: 'test' } });
+  await handler(req, res);
+  expect(res._getStatusCode()).toBe(401);
+});

--- a/frontend/lib/api.js
+++ b/frontend/lib/api.js
@@ -1,0 +1,9 @@
+export async function fetchFromAPI(path, options = {}) {
+  const url = `${process.env.BACKEND_URL}${path}`;
+  const res = await fetch(url, options);
+  if (!res.ok) {
+    const error = await res.text();
+    throw new Error(error);
+  }
+  return res.json();
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "autoprefixer": "^10.4.21",
+        "cookie": "^1.0.2",
         "next": "^15.3.5",
         "postcss": "^8.5.6",
         "react": "^19.1.0",
@@ -4139,6 +4140,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.44.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "cookie": "^1.0.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",

--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -1,0 +1,25 @@
+export default function Page({ page }) {
+  if (!page) {
+    return <p>Not Found</p>;
+  }
+  return (
+    <div>
+      <h1>{page.title}</h1>
+      <pre>{JSON.stringify(page.content, null, 2)}</pre>
+    </div>
+  );
+}
+
+export async function getStaticPaths() {
+  const res = await fetch(`${process.env.BACKEND_URL}/api/pages`);
+  const data = await res.json();
+  const paths = data.data.map((p) => ({ params: { slug: p.attributes.slug } }));
+  return { paths, fallback: true };
+}
+
+export async function getStaticProps({ params }) {
+  const res = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${params.slug}`);
+  const data = await res.json();
+  const page = data.data[0]?.attributes || null;
+  return { props: { page }, revalidate: 60 };
+}

--- a/frontend/pages/api/login.js
+++ b/frontend/pages/api/login.js
@@ -1,0 +1,31 @@
+import cookie from 'cookie';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' });
+  }
+  const { identifier, password } = req.body;
+  try {
+    const strapiRes = await fetch(`${process.env.BACKEND_URL}/api/auth/local`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier, password }),
+    });
+    const data = await strapiRes.json();
+    if (!strapiRes.ok) {
+      return res.status(strapiRes.status).json({ message: data.error?.message || 'Login failed' });
+    }
+    res.setHeader(
+      'Set-Cookie',
+      cookie.serialize('jwt', data.jwt, {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        maxAge: 60 * 60 * 24 * 7,
+      })
+    );
+    res.status(200).json({ user: data.user });
+  } catch (err) {
+    res.status(500).json({ message: 'Error connecting to backend' });
+  }
+}

--- a/frontend/pages/api/preview.js
+++ b/frontend/pages/api/preview.js
@@ -1,0 +1,16 @@
+export default async function handler(req, res) {
+  const { secret, slug = '' } = req.query;
+  if (secret !== process.env.PREVIEW_SECRET) {
+    return res.status(401).json({ message: 'Invalid token' });
+  }
+
+  const pageRes = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${slug}`);
+  const pageData = await pageRes.json();
+  if (!pageData.data?.length) {
+    return res.status(404).json({ message: 'Not Found' });
+  }
+
+  res.setPreviewData({});
+  res.writeHead(307, { Location: `/${slug}` });
+  res.end();
+}

--- a/frontend/pages/appointments.js
+++ b/frontend/pages/appointments.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export default function Appointments() {
+  const [appointments, setAppointments] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`${process.env.BACKEND_URL}/api/appointments`);
+        const data = await res.json();
+        setAppointments(data.data || []);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div>
+      <h1>Appointments</h1>
+      <ul>
+        {appointments.map((a) => (
+          <li key={a.id}>{a.attributes.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+
+export default function Login() {
+  const [identifier, setIdentifier] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError(null);
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ identifier, password }),
+    });
+    if (res.ok) {
+      window.location.href = '/dashboard';
+    } else {
+      const data = await res.json();
+      setError(data.message || 'Login failed');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        value={identifier}
+        onChange={(e) => setIdentifier(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="Password"
+      />
+      <button type="submit">Login</button>
+      {error && <p>{error}</p>}
+    </form>
+  );
+}

--- a/frontend/pages/store.js
+++ b/frontend/pages/store.js
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+
+export default function Store() {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`${process.env.BACKEND_URL}/api/products`);
+        const data = await res.json();
+        setProducts(data.data || []);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  return (
+    <div>
+      <h1>Store</h1>
+      <ul>
+        {products.map((p) => (
+          <li key={p.id}>{p.attributes.name} - ${p.attributes.price}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add initial frontend pages for appointments, store and dynamic slugs
- create preview and login API routes
- add simple login page and helper API utils
- add tests for new API routes

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_686ed72a47908328808ab77b99ccecd8