### PR TITLE
Implement upgrade step 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,5 @@ BACKEND_URL=http://localhost:1337
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+VIDEO_CALL_PROVIDER_KEY=your_video_service_key
 PREVIEW_SECRET=someRandomPreviewSecret

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:18-alpine
 WORKDIR /app
-COPY package.json ./
+COPY package.json package-lock.json* ./
 RUN npm install --production
 COPY . .
+RUN npm run build
+ENV NODE_ENV=production
 CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./backend:/app
       - backend-node-modules:/app/node_modules
-    command: sh -c "npm install && npm run build && npm run start"
+    command: npm run start
     environment:
       DATABASE_CLIENT: postgres
       DATABASE_HOST: db
@@ -27,6 +27,9 @@ services:
       API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       CLIENT_URL: http://localhost:3000
       PREVIEW_SECRET: someRandomPreviewSecret
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET}
+      VIDEO_CALL_PROVIDER_KEY: ${VIDEO_CALL_PROVIDER_KEY}
     ports:
       - '1337:1337'
     depends_on:
@@ -36,9 +39,10 @@ services:
     volumes:
       - ./frontend:/app
       - frontend-node-modules:/app/node_modules
-    command: sh -c "npm install && npm run build && npm start"
+    command: npm start
     environment:
       BACKEND_URL: http://localhost:1337
+      NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${NEXT_PUBLIC_STRIPE_PUBLIC_KEY}
     ports:
       - '3000:3000'
     depends_on:


### PR DESCRIPTION
## Summary
- add placeholder for video call service in `.env.example`
- build Strapi in production in `backend/Dockerfile`
- pass Stripe and video provider env vars via `docker-compose.yml`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686ed9c1d6248328a98956c4680d13bc