### PR TITLE
Add Craft.js editing on homepage

### DIFF
--- a/frontend/components/Container.js
+++ b/frontend/components/Container.js
@@ -1,0 +1,27 @@
+import { useNode } from '@craftjs/core';
+import PropTypes from 'prop-types';
+
+export const Container = ({ children, padding }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <div ref={(ref) => connect(drag(ref))} style={{ padding }}>
+      {children}
+    </div>
+  );
+};
+
+Container.propTypes = {
+  padding: PropTypes.string,
+  children: PropTypes.node,
+};
+
+Container.craft = {
+  props: {
+    padding: '20px',
+  },
+  rules: {
+    canDrag: () => true,
+  },
+};

--- a/frontend/components/Text.js
+++ b/frontend/components/Text.js
@@ -1,0 +1,25 @@
+import { useNode } from '@craftjs/core';
+import PropTypes from 'prop-types';
+
+export const Text = ({ text, fontSize }) => {
+  const {
+    connectors: { connect, drag },
+  } = useNode();
+  return (
+    <p ref={(ref) => connect(drag(ref))} style={{ fontSize }}>
+      {text}
+    </p>
+  );
+};
+
+Text.propTypes = {
+  text: PropTypes.string,
+  fontSize: PropTypes.string,
+};
+
+Text.craft = {
+  props: {
+    text: 'Edit me',
+    fontSize: '16px',
+  },
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,10 +8,12 @@
       "name": "frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@craftjs/core": "^0.2.12",
         "autoprefixer": "^10.4.21",
         "cookie": "^1.0.2",
         "next": "^15.3.5",
         "postcss": "^8.5.6",
+        "prop-types": "^15.8.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^4.1.11"
@@ -1893,6 +1895,37 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@craftjs/core": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@craftjs/core/-/core-0.2.12.tgz",
+      "integrity": "sha512-M9WZ6SuvGw6Ue2iXouPiqLzzsxOynn1HVugzlm8q98ulMdhn0BDI3XZdD3ErUdUe4kk4y2Ak9E0dtzVjC51JLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@craftjs/utils": "^0.2.5",
+        "debounce": "^1.2.0",
+        "lodash": "^4.17.21",
+        "tiny-invariant": "^1.0.6"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/@craftjs/utils": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@craftjs/utils/-/utils-0.2.5.tgz",
+      "integrity": "sha512-ANzAkGmQBe6fi7F2x6dhiN2hN9yBDfW+mQ2XJv8bJMIx+0h5Kbv04U4WXaFfMhjcC7DzfPnGkdg7/9gFkd5qVA==",
+      "license": "MIT",
+      "dependencies": {
+        "immer": "^9.0.6",
+        "lodash": "^4.17.21",
+        "nanoid": "^3.1.23",
+        "shallowequal": "^1.1.0",
+        "tiny-invariant": "^1.0.6"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.0.2",
@@ -4207,6 +4240,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -4724,6 +4763,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/immer": {
+      "version": "9.0.21",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
+      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-local": {
@@ -5590,7 +5639,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5710,12 +5758,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6115,6 +6181,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6410,6 +6485,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6663,6 +6755,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.2",
@@ -7152,6 +7250,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tldts": {
       "version": "6.1.86",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,13 +9,15 @@
     "test": "jest"
   },
   "dependencies": {
+    "@craftjs/core": "^0.2.12",
     "autoprefixer": "^10.4.21",
+    "cookie": "^1.0.2",
     "next": "^15.3.5",
     "postcss": "^8.5.6",
+    "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.11",
-    "cookie": "^1.0.2"
+    "tailwindcss": "^4.1.11"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,5 +1,20 @@
 import React from 'react';
+import { Editor, Frame, Element } from '@craftjs/core';
+import { Container } from '../components/Container';
+import { Text } from '../components/Text';
 
 export default function Home() {
-  return <h1>Welcome to the frontend</h1>;
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return (
+    <Editor resolver={{ Container, Text }}>
+      <Frame>
+        <Element is={Container} padding="40px" canvas>
+          <Text text="Welcome to the frontend" fontSize="24px" />
+        </Element>
+      </Frame>
+    </Editor>
+  );
 }


### PR DESCRIPTION
## Summary
- install `@craftjs/core` and `prop-types`
- add basic Craft.js components (`Container` and `Text`)
- update homepage to use Craft.js editor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686edb917adc8328a26187fa4c1550f7