### PR TITLE
Update README with upgrade features

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,18 @@ frontend/  # Next.js application
 docker-compose.yml
 ```
 
-Both apps are basic starters. The backend exposes a single `Page` content type and the frontend contains a simple page and API route with Tailwind configured.
+Both apps started as minimal starters but have been expanded with additional features:
+
+- **Backend**
+  - Collection types for Pages, Products, Orders, Appointments and Video Calls.
+  - Appointment creation checks for time slot conflicts.
+  - Orders are created automatically from the Stripe webhook.
+  - Preview mode enabled via `CLIENT_URL` and `PREVIEW_SECRET`.
+- **Frontend**
+  - Pages for the dashboard, appointments, store and dynamic `[slug]` routes.
+  - Login form that stores the Strapi JWT using an API route.
+  - Preview and login API routes.
+  - The homepage is editable with Craft.js components.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- document backend collection types and preview mode
- highlight new frontend pages and Craft.js integration

## Testing
- `cd backend && npm test --silent`
- `cd ../frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_686edd0842ac832899b8f613fae05d02