### PR TITLE
Fix Next.js build failure when backend unavailable

### DIFF
--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -11,15 +11,25 @@ export default function Page({ page }) {
 }
 
 export async function getStaticPaths() {
-  const res = await fetch(`${process.env.BACKEND_URL}/api/pages`);
-  const data = await res.json();
-  const paths = data.data.map((p) => ({ params: { slug: p.attributes.slug } }));
-  return { paths, fallback: true };
+  try {
+    const res = await fetch(`${process.env.BACKEND_URL}/api/pages`);
+    const data = await res.json();
+    const paths = data.data.map((p) => ({ params: { slug: p.attributes.slug } }));
+    return { paths, fallback: true };
+  } catch (err) {
+    console.error(err);
+    return { paths: [], fallback: true };
+  }
 }
 
 export async function getStaticProps({ params }) {
-  const res = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${params.slug}`);
-  const data = await res.json();
-  const page = data.data[0]?.attributes || null;
-  return { props: { page }, revalidate: 60 };
+  try {
+    const res = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${params.slug}`);
+    const data = await res.json();
+    const page = data.data[0]?.attributes || null;
+    return { props: { page }, revalidate: 60 };
+  } catch (err) {
+    console.error(err);
+    return { props: { page: null }, revalidate: 60 };
+  }
 }


### PR DESCRIPTION
## Summary
- handle fetch failures gracefully in dynamic page generation

## Testing
- `npm --prefix backend test`
- `npm --prefix frontend test`


------
https://chatgpt.com/codex/tasks/task_b_686f7692545883289a232cabbc362e03