### PR TITLE
Fix missing React imports for Next.js build

### DIFF
--- a/frontend/components/Container.js
+++ b/frontend/components/Container.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useNode } from '@craftjs/core';
 import PropTypes from 'prop-types';
 

--- a/frontend/components/Text.js
+++ b/frontend/components/Text.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useNode } from '@craftjs/core';
 import PropTypes from 'prop-types';
 

--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function Page({ page }) {
   if (!page) {
     return <p>Not Found</p>;

--- a/frontend/pages/appointments.js
+++ b/frontend/pages/appointments.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Appointments() {
   const [appointments, setAppointments] = useState([]);

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 export default function Login() {
   const [identifier, setIdentifier] = useState('');

--- a/frontend/pages/store.js
+++ b/frontend/pages/store.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Store() {
   const [products, setProducts] = useState([]);


### PR DESCRIPTION
## Summary
- add explicit `React` import in pages and components using JSX

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686f77e36b408328bc4bf02ee21e6b04