### PR TITLE
Fix missing Stripe module on backend startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./backend:/app
       - backend-node-modules:/app/node_modules
-    command: npm run start
+    command: sh -c "npm install --production && npm run start"
     environment:
       DATABASE_CLIENT: postgres
       DATABASE_HOST: db


### PR DESCRIPTION
## Summary
- ensure backend installs dependencies on container start

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686f7a8684988328b9aac503a6bcd3f8