### PR TITLE
Add JWT secret automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The script will:
 
 1. Install Node.js 18 using NodeSource.
 2. Ensure Docker is running and your user is part of the `docker` group.
-3. Copy `.env.example` to `.env` if needed.
+3. Copy `.env.example` to `.env` if needed and generate a random `JWT_SECRET`.
 4. Install backend and frontend dependencies.
 5. Build and launch the Docker containers.
 

--- a/backend/config/plugins.js
+++ b/backend/config/plugins.js
@@ -1,0 +1,7 @@
+module.exports = ({ env }) => ({
+  'users-permissions': {
+    config: {
+      jwtSecret: env('JWT_SECRET'),
+    },
+  },
+});

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -40,6 +40,12 @@ if [ ! -f .env ]; then
     cp .env.example .env
 fi
 
+# Generate a JWT secret if the placeholder value is present
+if grep -q '^JWT_SECRET=changeme' .env; then
+    new_secret=$(node -e "console.log(require('crypto').randomBytes(32).toString('base64'))")
+    sed -i "s|^JWT_SECRET=.*|JWT_SECRET=$new_secret|" .env
+fi
+
 # Build and start the application stack
 # (remove '--build' on subsequent runs for faster startup)
 if command -v docker &>/dev/null && docker compose version &>/dev/null; then


### PR DESCRIPTION
## Summary
- configure Strapi users-permissions plugin to read JWT secret from env
- generate a JWT secret in the setup script if the placeholder is detected
- document secret generation in the README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686f7e2a20948328b66e5e636ce2cfa4