### PR TITLE
Ensure JWT secret passes to Strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ repo-root/
 
 ## Development
 
-1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS`, `ADMIN_JWT_SECRET` and `API_TOKEN_SALT`).
+1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS`, `ADMIN_JWT_SECRET`, `API_TOKEN_SALT` and `JWT_SECRET`).
 2. Start the stack with Docker Compose (dependencies will be installed automatically):
    ```bash
    docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       DATABASE_SSL: 'false'
       APP_KEYS: change_me
       ADMIN_JWT_SECRET: changeme
+      JWT_SECRET: ${JWT_SECRET}
       API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       CLIENT_URL: http://localhost:3000
       PREVIEW_SECRET: someRandomPreviewSecret


### PR DESCRIPTION
## Summary
- add JWT_SECRET environment to docker-compose
- remove sed step from setup script
- note JWT_SECRET in README setup docs

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_686f80c20d78832890fbfdea5ab4f856