### PR TITLE
Fix hydration mismatch with dynamic imports

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import { Editor, Frame, Element } from '@craftjs/core';
+import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
 
-export default function Home() {
-  if (typeof window === 'undefined') {
-    return null;
-  }
+const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), { ssr: false });
+const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), { ssr: false });
+const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), { ssr: false });
 
+export default function Home() {
   return (
     <Editor resolver={{ Container, Text }}>
       <Frame>


### PR DESCRIPTION
## Summary
- disable SSR for craftjs components in index page to prevent hydration mismatch

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686f8e8e1e648328bf7f213ac9fc5311