### PR TITLE
Load pages from Strapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository provides an example of a full-stack project using a Next.js fron
   - Pages for the dashboard, appointments, store and dynamic `[slug]` routes.
   - Login form that stores the Strapi JWT using an API route.
   - Preview and login API routes.
-  - The homepage is editable with Craft.js components.
+  - All pages from Strapi, including the homepage, are editable with Craft.js components.
 
 ## Structure
 

--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -1,14 +1,34 @@
 import React from 'react';
+import dynamic from 'next/dynamic';
+import { Container } from '../components/Container';
+import { Text } from '../components/Text';
+
+const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), {
+  ssr: false,
+});
+const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), {
+  ssr: false,
+});
+const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), {
+  ssr: false,
+});
 
 export default function Page({ page }) {
   if (!page) {
     return <p>Not Found</p>;
   }
+  const hasContent = page.content && Object.keys(page.content).length > 0;
+
   return (
-    <div>
-      <h1>{page.title}</h1>
-      <pre>{JSON.stringify(page.content, null, 2)}</pre>
-    </div>
+    <Editor resolver={{ Container, Text }}>
+      <Frame data={hasContent ? page.content : undefined}>
+        {!hasContent && (
+          <Element is={Container} padding="40px" canvas>
+            <Text text={page.title} fontSize="24px" />
+          </Element>
+        )}
+      </Frame>
+    </Editor>
   );
 }
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -7,14 +7,36 @@ const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), { 
 const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), { ssr: false });
 const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), { ssr: false });
 
-export default function Home() {
+export default function Home({ page }) {
+  if (!page) {
+    return <p>Not Found</p>;
+  }
+
+  const hasContent = page.content && Object.keys(page.content).length > 0;
+
   return (
     <Editor resolver={{ Container, Text }}>
-      <Frame>
-        <Element is={Container} padding="40px" canvas>
-          <Text text="Welcome to the frontend" fontSize="24px" />
-        </Element>
+      <Frame data={hasContent ? page.content : undefined}>
+        {!hasContent && (
+          <Element is={Container} padding="40px" canvas>
+            <Text text="Welcome to the frontend" fontSize="24px" />
+          </Element>
+        )}
       </Frame>
     </Editor>
   );
+}
+
+export async function getStaticProps() {
+  try {
+    const res = await fetch(
+      `${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=home`
+    );
+    const data = await res.json();
+    const page = data.data[0]?.attributes || null;
+    return { props: { page }, revalidate: 60 };
+  } catch (err) {
+    console.error(err);
+    return { props: { page: null }, revalidate: 60 };
+  }
 }


### PR DESCRIPTION
## Summary
- fetch `home` page for root path and render with Craft.js
- render dynamic `[slug]` pages with Craft.js
- update docs about editing Strapi pages

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_686f91ec4984832890c6e1a0515efdbd