### PR TITLE
Add ALLOWED_DEV_ORIGIN config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ DATABASE_PASSWORD=strapi
 DATABASE_SSL=false
 CLIENT_URL=http://localhost:3000
 BACKEND_URL=http://backend:1337
+ALLOWED_DEV_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ repo-root/
    docker compose up --build
    ```
 3. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
+4. If you access the frontend using a different hostname or IP, set `ALLOWED_DEV_ORIGIN` in `.env` to that URL so Next.js allows cross-origin requests during development.
 
 ## Running tests
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     command: sh -c "npm install && npm run dev"
     environment:
       BACKEND_URL: http://backend:1337
+      ALLOWED_DEV_ORIGIN: ${ALLOWED_DEV_ORIGIN}
       NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${NEXT_PUBLIC_STRIPE_PUBLIC_KEY}
     ports:
       - '3000:3000'

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -5,6 +5,8 @@ WORKDIR /app
 # can fetch data during `next build` when `getStaticProps` runs.
 ARG BACKEND_URL=http://backend:1337
 ENV BACKEND_URL=$BACKEND_URL
+ARG ALLOWED_DEV_ORIGIN=http://localhost:3000
+ENV ALLOWED_DEV_ORIGIN=$ALLOWED_DEV_ORIGIN
 
 COPY package*.json ./
 # Install all dependencies so the build step has access to dev packages

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,5 +4,8 @@ const nextConfig = {
   env: {
     BACKEND_URL: process.env.BACKEND_URL,
   },
+  experimental: {
+    allowedDevOrigins: [process.env.ALLOWED_DEV_ORIGIN || 'http://localhost:3000'],
+  },
 };
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow configuring Next.js dev origins via `ALLOWED_DEV_ORIGIN`
- document usage in README and `.env.example`
- pass through docker-compose and Dockerfile

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_686fa502f8c48328a4bf5ebd2beceff5