### PR TITLE
Fix cross origin dev warning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ DATABASE_PASSWORD=strapi
 DATABASE_SSL=false
 CLIENT_URL=http://localhost:3000
 BACKEND_URL=http://backend:1337
+# Comma-separated list of origins allowed to load Next.js dev resources
 ALLOWED_DEV_ORIGIN=http://localhost:3000
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=sk_test_xxx

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ repo-root/
    docker compose up --build
    ```
 3. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
-4. If you access the frontend using a different hostname or IP, set `ALLOWED_DEV_ORIGIN` in `.env` to that URL so Next.js allows cross-origin requests during development.
+4. If you access the frontend using a different hostname or IP, set `ALLOWED_DEV_ORIGIN` in `.env` to that URL. Multiple origins can be provided as a comma-separated list so Next.js allows cross-origin requests during development.
 
 ## Running tests
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,7 +5,13 @@ const nextConfig = {
     BACKEND_URL: process.env.BACKEND_URL,
   },
   experimental: {
-    allowedDevOrigins: [process.env.ALLOWED_DEV_ORIGIN || 'http://localhost:3000'],
+    // Allow multiple origins in development, separated by commas in
+    // the ALLOWED_DEV_ORIGIN environment variable. This prevents
+    // cross-origin warnings when accessing the dev server from other
+    // machines on the network.
+    allowedDevOrigins: (process.env.ALLOWED_DEV_ORIGIN || 'http://localhost:3000')
+      .split(',')
+      .map((origin) => origin.trim()),
   },
 };
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- allow multiple comma-separated origins in `next.config.js`
- document ALLOWED_DEV_ORIGIN usage in README and `.env.example`

## Testing
- `npm test` in `backend`
- `npm install` and `npm test` in `frontend`

------
https://chatgpt.com/codex/tasks/task_b_686fe947fa18832882315c89b13b054a