### PR TITLE
Add detailed page fetching logs

### DIFF
--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -32,11 +32,17 @@ export default function Page({ page }) {
   );
 }
 
-export async function getStaticPaths() {
-  try {
-    const res = await fetch(`${process.env.BACKEND_URL}/api/pages`);
+  export async function getStaticPaths() {
+    try {
+    const url = `${process.env.BACKEND_URL}/api/pages`;
+    console.log('getStaticPaths fetch:', url);
+    const res = await fetch(url);
+    console.log('getStaticPaths status:', res.status);
     const data = await res.json();
-    const paths = data.data.map((p) => ({ params: { slug: p.attributes.slug } }));
+    if (!Array.isArray(data.data)) {
+      console.warn('Unexpected pages response:', data);
+    }
+    const paths = (data.data || []).map((p) => ({ params: { slug: p.attributes.slug } }));
     return { paths, fallback: true };
   } catch (err) {
     console.error(err);
@@ -46,9 +52,15 @@ export async function getStaticPaths() {
 
 export async function getStaticProps({ params }) {
   try {
-    const res = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${params.slug}`);
+    const url = `${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=${params.slug}`;
+    console.log('getStaticProps fetch:', url);
+    const res = await fetch(url);
+    console.log('getStaticProps status:', res.status);
     const data = await res.json();
-    const page = data.data[0]?.attributes || null;
+    if (!Array.isArray(data.data)) {
+      console.warn('Unexpected page response:', data);
+    }
+    const page = (data.data && data.data[0]?.attributes) || null;
     return { props: { page }, revalidate: 60 };
   } catch (err) {
     console.error(err);

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -27,18 +27,24 @@ export default function Home({ page }) {
   );
 }
 
-export async function getStaticProps() {
-  try {
-    const res = await fetch(
-      `${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=home`
-    );
+  export async function getStaticProps() {
+    try {
+    const url = `${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=home`;
+    console.log('getStaticProps(home) fetch:', url);
+    const res = await fetch(url);
+    console.log('getStaticProps(home) status:', res.status);
 
     if (!res.ok) {
+      const body = await res.text();
       console.warn(`Failed to load home page: ${res.status}`);
+      console.warn('Home page response body:', body);
       return { props: { page: null }, revalidate: 60 };
     }
 
     const data = await res.json();
+    if (!Array.isArray(data.data)) {
+      console.warn('Unexpected home page response:', data);
+    }
     const page = Array.isArray(data.data) && data.data.length > 0
       ? data.data[0].attributes
       : null;


### PR DESCRIPTION
## Summary
- log GET requests for `index.js` and `[slug].js`
- include HTTP status codes and body when failing
- warn about unexpected payload shapes

## Testing
- `cd backend && npm test --silent`
- `cd ../frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_686ff078cdc4832883d9c37b3a956329