### PR TITLE
Create default routes for pages

### DIFF
--- a/backend/src/api/page/controllers/page.js
+++ b/backend/src/api/page/controllers/page.js
@@ -1,0 +1,3 @@
+'use strict';
+const { createCoreController } = require('@strapi/strapi').factories;
+module.exports = createCoreController('api::page.page');

--- a/backend/src/api/page/routes/page.js
+++ b/backend/src/api/page/routes/page.js
@@ -1,0 +1,23 @@
+'use strict';
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/pages',
+      handler: 'page.find',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+    {
+      method: 'GET',
+      path: '/pages/:id',
+      handler: 'page.findOne',
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+  ],
+};

--- a/backend/src/api/page/services/page.js
+++ b/backend/src/api/page/services/page.js
@@ -1,0 +1,3 @@
+'use strict';
+const { createCoreService } = require('@strapi/strapi').factories;
+module.exports = createCoreService('api::page.page');


### PR DESCRIPTION
## Summary
- add Strapi controller, service and routes for page content type

## Testing
- `cd backend && npm test --silent`
- `cd ../frontend && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_686ff32b14f48328883e9d2cd89ac746