### PR TITLE
Fix craft editor crash on invalid page content

### DIFF
--- a/frontend/__tests__/isValidContent.test.js
+++ b/frontend/__tests__/isValidContent.test.js
@@ -1,0 +1,26 @@
+import { isValidContent } from '../lib/isValidContent';
+
+const resolver = {
+  Container: () => null,
+  Text: () => null,
+};
+
+test('returns false for empty content', () => {
+  expect(isValidContent({}, resolver)).toBe(false);
+});
+
+test('returns false when any node type is unknown', () => {
+  const content = {
+    ROOT: { type: 'Container' },
+    node1: { type: 'Unknown' },
+  };
+  expect(isValidContent(content, resolver)).toBe(false);
+});
+
+test('returns true for valid content', () => {
+  const content = {
+    ROOT: { type: 'Container' },
+    node1: { type: 'Text' },
+  };
+  expect(isValidContent(content, resolver)).toBe(true);
+});

--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -1,0 +1,16 @@
+export function isValidContent(content, resolver) {
+  if (!content || typeof content !== 'object') {
+    return false;
+  }
+  const keys = Object.keys(content);
+  if (keys.length === 0) {
+    return false;
+  }
+  for (const id of keys) {
+    const node = content[id];
+    if (!node || !node.type || !resolver[node.type]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -2,6 +2,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
+import { isValidContent } from '../lib/isValidContent';
 
 const resolver = { Container, Text };
 
@@ -19,13 +20,7 @@ export default function Page({ page }) {
   if (!page) {
     return <p>Not Found</p>;
   }
-  const hasContent =
-    page.content &&
-    typeof page.content === 'object' &&
-    page.content.ROOT &&
-    page.content.ROOT.type &&
-    resolver[page.content.ROOT.type] &&
-    Object.keys(page.content).length > 0;
+  const hasContent = isValidContent(page.content, resolver);
 
   return (
     <Editor resolver={resolver}>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
+import { isValidContent } from '../lib/isValidContent';
 
 const resolver = { Container, Text };
 
@@ -14,13 +15,7 @@ export default function Home({ page }) {
     return <p>Not Found</p>;
   }
 
-  const hasContent =
-    page.content &&
-    typeof page.content === 'object' &&
-    page.content.ROOT &&
-    page.content.ROOT.type &&
-    resolver[page.content.ROOT.type] &&
-    Object.keys(page.content).length > 0;
+  const hasContent = isValidContent(page.content, resolver);
 
   return (
     <Editor resolver={resolver}>


### PR DESCRIPTION
## Summary
- add library helper to check Craft.js page data
- guard pages against invalid content
- test new helper

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_68700b5462dc83289733f8efdd64f086