### PR TITLE
Integrate Craft.js editor into dashboard

### DIFF
--- a/frontend/components/SaveButton.js
+++ b/frontend/components/SaveButton.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useEditor } from '@craftjs/core';
+import PropTypes from 'prop-types';
+
+export function SaveButton({ onSave }) {
+  const { query } = useEditor();
+  return (
+    <button onClick={() => onSave(JSON.parse(query.serialize()))}>
+      Save
+    </button>
+  );
+}
+
+SaveButton.propTypes = {
+  onSave: PropTypes.func.isRequired,
+};

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -1,5 +1,82 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { Container } from '../components/Container';
+import { Text } from '../components/Text';
+import { isValidContent } from '../lib/isValidContent';
+
+const resolver = { Container, Text };
+
+const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), { ssr: false });
+const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), { ssr: false });
+const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), { ssr: false });
+const SaveButton = dynamic(() => import('../components/SaveButton').then(mod => mod.SaveButton), { ssr: false });
 
 export default function Dashboard() {
-  return <h1>Dashboard</h1>;
+  const [page, setPage] = useState(null);
+  const [content, setContent] = useState(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`${process.env.BACKEND_URL}/api/pages?filters[slug][$eq]=home`);
+        const data = await res.json();
+        const pageEntry = data.data && data.data[0];
+        if (pageEntry) {
+          setPage(pageEntry);
+          setContent(pageEntry.attributes.content);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  async function handleSave(json) {
+    if (!page) return;
+    try {
+      const jwtMatch = document.cookie.match(/(?:^|; )jwt=([^;]*)/);
+      const jwt = jwtMatch ? jwtMatch[1] : null;
+      const res = await fetch(`${process.env.BACKEND_URL}/api/pages/${page.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(jwt ? { Authorization: `Bearer ${jwt}` } : {}),
+        },
+        body: JSON.stringify({ data: { content: json } }),
+      });
+      if (!res.ok) {
+        console.error('Save failed:', await res.text());
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  if (!page) {
+    return <p>Loading...</p>;
+  }
+
+  const hasContent = isValidContent(content, resolver);
+
+  return (
+    <div>
+      <SaveButton onSave={handleSave} />
+      <Editor resolver={resolver} onNodesChange={(query) => {
+        try {
+          setContent(JSON.parse(query.serialize()));
+        } catch (e) {
+          console.error('Failed to parse nodes', e);
+        }
+      }}>
+        <Frame data={hasContent ? content : undefined}>
+          {!hasContent && (
+            <Element is={Container} padding="40px" canvas>
+              <Text text="Welcome" fontSize="24px" />
+            </Element>
+          )}
+        </Frame>
+      </Editor>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a `SaveButton` component which uses Craft.js `useEditor`
- replace dashboard page with a Craft.js editor
- allow saving page content back to Strapi

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68700e51466c83289804f2dcc7ccb4ad