### PR TITLE
Fix Craft.js content validation

### DIFF
--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -2,15 +2,32 @@ export function isValidContent(content, resolver) {
   if (!content || typeof content !== 'object') {
     return false;
   }
+
   const keys = Object.keys(content);
   if (keys.length === 0) {
     return false;
   }
+
   for (const id of keys) {
     const node = content[id];
     if (!node || !node.type || !resolver[node.type]) {
       return false;
     }
+
+    const children = [];
+    if (Array.isArray(node.nodes)) {
+      children.push(...node.nodes);
+    }
+    if (node.linkedNodes && typeof node.linkedNodes === 'object') {
+      children.push(...Object.values(node.linkedNodes));
+    }
+
+    for (const childId of children) {
+      if (!content[childId]) {
+        return false;
+      }
+    }
   }
+
   return true;
 }


### PR DESCRIPTION
## Summary
- fix `isValidContent` to detect missing child nodes when loading Craft.js data
- update tests (no changes necessary as they still pass)

## Testing
- `npm test --prefix frontend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_b_6870148df1fc83289802e8c466aee331