### PR TITLE
Fix favicon middleware path

### DIFF
--- a/backend/config/middlewares.js
+++ b/backend/config/middlewares.js
@@ -13,6 +13,11 @@ module.exports = [
   'strapi::query',
   'strapi::body',
   'strapi::session',
-  'strapi::favicon',
+  {
+    name: 'strapi::favicon',
+    config: {
+      path: './public/favicon.ico',
+    },
+  },
   'strapi::public',
 ];


### PR DESCRIPTION
## Summary
- configure Strapi favicon middleware to look for favicon in the public folder

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687019cef43083289236f4dcc7cea06b