### PR TITLE
Fix craft content validation

### DIFF
--- a/frontend/__tests__/isValidContent.test.js
+++ b/frontend/__tests__/isValidContent.test.js
@@ -24,3 +24,11 @@ test('returns true for valid content', () => {
   };
   expect(isValidContent(content, resolver)).toBe(true);
 });
+
+test('handles type objects with resolvedName', () => {
+  const content = {
+    ROOT: { type: { resolvedName: 'Container' } },
+    node1: { type: { resolvedName: 'Text' } },
+  };
+  expect(isValidContent(content, resolver)).toBe(true);
+});

--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -1,3 +1,16 @@
+function getTypeName(node) {
+  if (!node || !node.type) {
+    return null;
+  }
+  if (typeof node.type === 'string') {
+    return node.type;
+  }
+  if (typeof node.type === 'object' && node.type.resolvedName) {
+    return node.type.resolvedName;
+  }
+  return null;
+}
+
 export function isValidContent(content, resolver) {
   if (!content || typeof content !== 'object') {
     return false;
@@ -10,7 +23,8 @@ export function isValidContent(content, resolver) {
 
   for (const id of keys) {
     const node = content[id];
-    if (!node || !node.type || !resolver[node.type]) {
+    const typeName = getTypeName(node);
+    if (!typeName || !resolver[typeName]) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- handle craft.js serialized nodes that use `resolvedName`
- test isValidContent with `resolvedName` node types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_687019672dd4832886c56cf7b7680a01