### PR TITLE
Fix craft.js content validation

### DIFF
--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -24,7 +24,9 @@ export function isValidContent(content, resolver) {
   for (const id of keys) {
     const node = content[id];
     const typeName = getTypeName(node);
-    if (!typeName || !resolver[typeName]) {
+    const component = resolver[typeName];
+    if (!typeName || !component ||
+        (typeof component !== 'function' && typeof component !== 'object')) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- improve `isValidContent` to verify resolver components are functions or objects

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68701cfdfb108328a9367a0ed6f6c970