### PR TITLE
Configure Next.js editor in setup script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,4 @@ STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 VIDEO_CALL_PROVIDER_KEY=your_video_service_key
 PREVIEW_SECRET=someRandomPreviewSecret
+REACT_EDITOR=atom

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       BACKEND_URL: http://backend:1337
       ALLOWED_DEV_ORIGIN: ${ALLOWED_DEV_ORIGIN}
       NEXT_PUBLIC_STRIPE_PUBLIC_KEY: ${NEXT_PUBLIC_STRIPE_PUBLIC_KEY}
+      REACT_EDITOR: ${REACT_EDITOR}
     ports:
       - '3000:3000'
     depends_on:

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -65,6 +65,10 @@ if grep -q '^ALLOWED_DEV_ORIGIN=http://localhost:3000' .env; then
     echo "ALLOWED_DEV_ORIGIN set to http://${host_ip}:3000"
     sed -i "s|^NEXT_PUBLIC_BACKEND_URL=.*|NEXT_PUBLIC_BACKEND_URL=http://${host_ip}:1337|" .env
 fi
+# Set the React editor for Next.js dev overlay
+if ! grep -q '^REACT_EDITOR=' .env; then
+    echo 'REACT_EDITOR=atom' >> .env
+fi
 
 # Ensure docker-compose passes the JWT secret to the backend
 if ! grep -q 'JWT_SECRET:' docker-compose.yml; then


### PR DESCRIPTION
## Summary
- add `REACT_EDITOR` variable to `.env.example`
- pass the editor setting to frontend service
- ensure setup script writes `REACT_EDITOR=atom` if missing

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68701e078b30832881bad70e1c29dac7