### PR TITLE
Update allowed dev origin example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,8 @@ BACKEND_URL=http://backend:1337
 # URL reachable by browsers for API requests
 NEXT_PUBLIC_BACKEND_URL=http://localhost:1337
 # Comma-separated list of origins allowed to load Next.js dev resources
-ALLOWED_DEV_ORIGIN=http://localhost:3000
+# Example allowing both localhost and a LAN IP
+ALLOWED_DEV_ORIGIN=http://localhost:3000,http://192.168.2.20:3000
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_xxx
 STRIPE_SECRET_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx

--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ repo-root/
    docker compose up --build
    ```
 3. Visit `http://localhost:3000` for the frontend and `http://localhost:1337` for Strapi.
-4. If you access the frontend using a different hostname or IP, set `ALLOWED_DEV_ORIGIN` in `.env` to that URL. Multiple origins can be provided as a comma-separated list so Next.js allows cross-origin requests during development.
+4. If you access the frontend using a different hostname or IP, set `ALLOWED_DEV_ORIGIN` in `.env` to that URL. Multiple origins can be provided as a comma-separated list so Next.js allows cross-origin requests during development. For example:
+   ```bash
+   ALLOWED_DEV_ORIGIN=http://localhost:3000,http://192.168.2.20:3000
+   ```
 
 ## Running tests
 


### PR DESCRIPTION
## Summary
- document ALLOWED_DEV_ORIGIN usage with multiple origins
- show localhost and example LAN IP in `.env.example`

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687021b5e0988328b94246be43b4ef75