### PR TITLE
Display content when Craft.js disabled

### DIFF
--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -28,7 +28,14 @@ export default function Page({ page }) {
     return <p>Not Found</p>;
   }
   if (craftDisabled) {
-    return <p>{page.title}</p>;
+    return (
+      <div>
+        <p>{page.title}</p>
+        {page.content && (
+          <pre>{JSON.stringify(page.content, null, 2)}</pre>
+        )}
+      </div>
+    );
   }
   const hasContent = isValidContent(page.content, resolver);
 

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -66,7 +66,14 @@ export default function Dashboard() {
   }
 
   if (craftDisabled) {
-    return <p>{page.attributes?.title || 'Dashboard'}</p>;
+    return (
+      <div>
+        <p>{page.attributes?.title || 'Dashboard'}</p>
+        {page.attributes?.content && (
+          <pre>{JSON.stringify(page.attributes.content, null, 2)}</pre>
+        )}
+      </div>
+    );
   }
 
   const hasContent = isValidContent(content, resolver);


### PR DESCRIPTION
## Summary
- show serialized page content in `[slug]` page when Craft.js is disabled
- show serialized content in dashboard fallback

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_6870276e2fb08328a62064f417c930a0