### PR TITLE
Fix validation of page content in dashboard

### DIFF
--- a/frontend/__tests__/isValidContent.test.js
+++ b/frontend/__tests__/isValidContent.test.js
@@ -9,6 +9,13 @@ test('returns false for empty content', () => {
   expect(isValidContent({}, resolver)).toBe(false);
 });
 
+test('returns false when ROOT node is missing', () => {
+  const content = {
+    node1: { type: 'Container' },
+  };
+  expect(isValidContent(content, resolver)).toBe(false);
+});
+
 test('returns false when any node type is unknown', () => {
   const content = {
     ROOT: { type: 'Container' },

--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -21,6 +21,10 @@ export function isValidContent(content, resolver) {
     return false;
   }
 
+  if (!content.ROOT) {
+    return false;
+  }
+
   for (const id of keys) {
     const node = content[id];
     const typeName = getTypeName(node);


### PR DESCRIPTION
## Summary
- ensure the content JSON includes a ROOT node
- test that missing ROOT node invalidates the content

## Testing
- `npm --prefix frontend test -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_b_68702c2429408328acd4128a343b5bb0