### PR TITLE
Handle Craft.js for unauthenticated users

### DIFF
--- a/frontend/lib/useCraftDisabled.js
+++ b/frontend/lib/useCraftDisabled.js
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+
+export function useCraftDisabled() {
+  const [disabled, setDisabled] = useState(
+    process.env.NEXT_PUBLIC_DISABLE_CRAFTJS === 'true'
+  );
+
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_DISABLE_CRAFTJS === 'true') {
+      return;
+    }
+    if (typeof document !== 'undefined') {
+      const loggedIn = document.cookie.includes('jwt=');
+      if (!loggedIn) {
+        setDisabled(true);
+      }
+    }
+  }, []);
+
+  return disabled;
+}

--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -3,27 +3,22 @@ import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
 import { isValidContent } from '../lib/isValidContent';
-
-const craftDisabled = process.env.NEXT_PUBLIC_DISABLE_CRAFTJS === 'true';
+import { useCraftDisabled } from '../lib/useCraftDisabled';
 
 const resolver = { Container, Text };
 
-let Editor = null;
-let Frame = null;
-let Element = null;
-if (!craftDisabled) {
-  Editor = dynamic(() => import('@craftjs/core').then((mod) => mod.Editor), {
-    ssr: false,
-  });
-  Frame = dynamic(() => import('@craftjs/core').then((mod) => mod.Frame), {
-    ssr: false,
-  });
-  Element = dynamic(() => import('@craftjs/core').then((mod) => mod.Element), {
-    ssr: false,
-  });
-}
+const Editor = dynamic(() => import('@craftjs/core').then((mod) => mod.Editor), {
+  ssr: false,
+});
+const Frame = dynamic(() => import('@craftjs/core').then((mod) => mod.Frame), {
+  ssr: false,
+});
+const Element = dynamic(() => import('@craftjs/core').then((mod) => mod.Element), {
+  ssr: false,
+});
 
 export default function Page({ page }) {
+  const craftDisabled = useCraftDisabled();
   if (!page) {
     return <p>Not Found</p>;
   }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -3,6 +3,7 @@ import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
 import { isValidContent } from '../lib/isValidContent';
+import { useCraftDisabled } from '../lib/useCraftDisabled';
 
 const resolver = { Container, Text };
 
@@ -11,8 +12,21 @@ const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), { ss
 const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), { ssr: false });
 
 export default function Home({ page }) {
+  const craftDisabled = useCraftDisabled();
+
   if (!page) {
     return <p>Not Found</p>;
+  }
+
+  if (craftDisabled) {
+    return (
+      <div>
+        <p>{page.title}</p>
+        {page.content && (
+          <pre>{JSON.stringify(page.content, null, 2)}</pre>
+        )}
+      </div>
+    );
   }
 
   const hasContent = isValidContent(page.content, resolver);


### PR DESCRIPTION
## Summary
- add `useCraftDisabled` hook
- disable Craft.js editor for visitors without a JWT cookie
- use the hook in `index.js` and `[slug].js`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68702a8426a48328b7b56636b3ef4001