### PR TITLE
Update setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ The script will:
 2. Ensure Docker is running and your user is part of the `docker` group.
 3. Copy `.env.example` to `.env` if needed and generate a random `JWT_SECRET`.
 4. Install backend and frontend dependencies.
-5. Build and launch the Docker containers.
+5. Build the Docker containers and display a command you can run to start them.
 
-After it finishes you can visit the frontend at `http://localhost:3000` and the Strapi admin at `http://localhost:1337`.
+After running `docker compose up --build` you can visit the frontend at `http://localhost:3000` and the Strapi admin at `http://localhost:1337`.
 
 If Docker fails with a permission denied error when accessing `/var/run/docker.sock`, open a new terminal session or run `newgrp docker` so your shell picks up the new group membership, then rerun the last command.
 

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -75,10 +75,11 @@ if ! grep -q 'JWT_SECRET:' docker-compose.yml; then
     sed -i '/ADMIN_JWT_SECRET:/a\      JWT_SECRET: ${JWT_SECRET}' docker-compose.yml
 fi
 
-# Build and start the application stack
-# (remove '--build' on subsequent runs for faster startup)
+# Final message with instructions to start the stack
+echo
+echo "Setup complete! Review the .env file then launch the containers with:"
 if command -v docker &>/dev/null && docker compose version &>/dev/null; then
-    docker compose up --build
+    echo "  docker compose up --build"
 else
-    docker-compose up --build
+    echo "  docker-compose up --build"
 fi


### PR DESCRIPTION
## Summary
- tweak setup script so it no longer launches containers automatically
- clarify README instructions on running `docker compose up`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68702c5d4854832899db4dd86737c6bd