### PR TITLE
Fix Craft.js resolver error

### DIFF
--- a/frontend/__tests__/isValidContent.test.js
+++ b/frontend/__tests__/isValidContent.test.js
@@ -39,3 +39,11 @@ test('handles type objects with resolvedName', () => {
   };
   expect(isValidContent(content, resolver)).toBe(true);
 });
+
+test('allows basic HTML elements', () => {
+  const content = {
+    ROOT: { type: 'div', nodes: ['n1'] },
+    n1: { type: 'Container' },
+  };
+  expect(isValidContent(content, resolver)).toBe(true);
+});

--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -16,6 +16,11 @@ export function isValidContent(content, resolver) {
     return false;
   }
 
+  const DOM_ELEMENTS = [
+    'a', 'div', 'p', 'span', 'img', 'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5',
+    'h6', 'button', 'section', 'article', 'header', 'footer', 'nav', 'main'
+  ];
+
   const keys = Object.keys(content);
   if (keys.length === 0) {
     return false;
@@ -29,8 +34,16 @@ export function isValidContent(content, resolver) {
     const node = content[id];
     const typeName = getTypeName(node);
     const component = resolver[typeName];
-    if (!typeName || !component ||
-        (typeof component !== 'function' && typeof component !== 'object')) {
+    if (!typeName) {
+      return false;
+    }
+    if (!component) {
+      if (!DOM_ELEMENTS.includes(typeName)) {
+        return false;
+      }
+    } else if (
+      typeof component !== 'function' && typeof component !== 'object'
+    ) {
       return false;
     }
 


### PR DESCRIPTION
## Summary
- update `isValidContent` to allow DOM elements
- add regression test

## Testing
- `cd backend && npm test`
- `cd ../frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_b_68708da121cc8328bb59d46d443b88c7