### PR TITLE
Expand HTML whitelist for Craft.js content validation

### DIFF
--- a/frontend/__tests__/isValidContent.test.js
+++ b/frontend/__tests__/isValidContent.test.js
@@ -47,3 +47,11 @@ test('allows basic HTML elements', () => {
   };
   expect(isValidContent(content, resolver)).toBe(true);
 });
+
+test('allows extended HTML elements like svg', () => {
+  const content = {
+    ROOT: { type: 'svg', nodes: ['c1'] },
+    c1: { type: 'circle' },
+  };
+  expect(isValidContent(content, resolver)).toBe(true);
+});

--- a/frontend/lib/isValidContent.js
+++ b/frontend/lib/isValidContent.js
@@ -17,8 +17,46 @@ export function isValidContent(content, resolver) {
   }
 
   const DOM_ELEMENTS = [
-    'a', 'div', 'p', 'span', 'img', 'ul', 'li', 'h1', 'h2', 'h3', 'h4', 'h5',
-    'h6', 'button', 'section', 'article', 'header', 'footer', 'nav', 'main'
+    'a',
+    'article',
+    'button',
+    'circle',
+    'div',
+    'em',
+    'footer',
+    'form',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'header',
+    'hr',
+    'img',
+    'input',
+    'label',
+    'li',
+    'main',
+    'nav',
+    'option',
+    'p',
+    'path',
+    'rect',
+    'section',
+    'select',
+    'span',
+    'strong',
+    'svg',
+    'table',
+    'tbody',
+    'td',
+    'text',
+    'textarea',
+    'th',
+    'thead',
+    'tr',
+    'ul'
   ];
 
   const keys = Object.keys(content);


### PR DESCRIPTION
## Summary
- expand allowed DOM tags in `isValidContent`
- test new allowed elements

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_6870915efec08328817eeb10931d56af