### PR TITLE
Add craft component display names

### DIFF
--- a/frontend/components/Container.js
+++ b/frontend/components/Container.js
@@ -19,6 +19,7 @@ Container.propTypes = {
 };
 
 Container.craft = {
+  displayName: 'Container',
   props: {
     padding: '20px',
   },

--- a/frontend/components/Text.js
+++ b/frontend/components/Text.js
@@ -19,6 +19,7 @@ Text.propTypes = {
 };
 
 Text.craft = {
+  displayName: 'Text',
   props: {
     text: 'Edit me',
     fontSize: '16px',


### PR DESCRIPTION
## Summary
- register stable display names for craft components

## Testing
- `npm test -- --runTestsByPath __tests__/isValidContent.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68709addd6308328b273b708984583a0