### PR TITLE
Seed homepage with starter content

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,11 +7,26 @@ module.exports = {
       filters: { slug: 'home' },
     });
     if (existingHome.length === 0) {
+      // Seed the homepage with a simple Container/Text structure so the
+      // frontend isn't empty on first run.
+      const defaultHomeContent = {
+        ROOT: {
+          type: 'Container',
+          isCanvas: true,
+          props: { padding: '40px' },
+          nodes: ['text1'],
+        },
+        text1: {
+          type: 'Text',
+          props: { text: 'Welcome to the frontend', fontSize: '24px' },
+        },
+      };
+
       await strapi.entityService.create('api::page.page', {
         data: {
           title: 'Home',
           slug: 'home',
-          content: {},
+          content: defaultHomeContent,
         },
       });
     }


### PR DESCRIPTION
## Summary
- seed the 'home' page with a default Container/Text structure during Strapi bootstrap

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_68709e2a6d608328adeb94ed750bb7f5