### PR TITLE
Fix dynamic loading of Craft.js components

### DIFF
--- a/frontend/pages/[slug].js
+++ b/frontend/pages/[slug].js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
@@ -9,12 +9,15 @@ const resolver = { Container, Text };
 
 const Editor = dynamic(() => import('@craftjs/core').then((mod) => mod.Editor), {
   ssr: false,
+  suspense: true,
 });
 const Frame = dynamic(() => import('@craftjs/core').then((mod) => mod.Frame), {
   ssr: false,
+  suspense: true,
 });
 const Element = dynamic(() => import('@craftjs/core').then((mod) => mod.Element), {
   ssr: false,
+  suspense: true,
 });
 
 export default function Page({ page }) {
@@ -35,15 +38,17 @@ export default function Page({ page }) {
   const hasContent = isValidContent(page.content, resolver);
 
   return (
-    <Editor resolver={resolver} enabled={!craftDisabled}>
-      <Frame data={hasContent ? page.content : undefined}>
-        {!hasContent && (
-          <Element is={Container} padding="40px" canvas>
-            <Text text={page.title} fontSize="24px" />
-          </Element>
-        )}
-      </Frame>
-    </Editor>
+    <Suspense fallback={null}>
+      <Editor resolver={resolver} enabled={!craftDisabled}>
+        <Frame data={hasContent ? page.content : undefined}>
+          {!hasContent && (
+            <Element is={Container} padding="40px" canvas>
+              <Text text={page.title} fontSize="24px" />
+            </Element>
+          )}
+        </Frame>
+      </Editor>
+    </Suspense>
   );
 }
 

--- a/frontend/pages/dashboard.js
+++ b/frontend/pages/dashboard.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
@@ -13,10 +13,22 @@ let Frame = null;
 let Element = null;
 let SaveButton = null;
 if (!craftDisabled) {
-  Editor = dynamic(() => import('@craftjs/core').then((mod) => mod.Editor), { ssr: false });
-  Frame = dynamic(() => import('@craftjs/core').then((mod) => mod.Frame), { ssr: false });
-  Element = dynamic(() => import('@craftjs/core').then((mod) => mod.Element), { ssr: false });
-  SaveButton = dynamic(() => import('../components/SaveButton').then((mod) => mod.SaveButton), { ssr: false });
+  Editor = dynamic(() => import('@craftjs/core').then((mod) => mod.Editor), {
+    ssr: false,
+    suspense: true,
+  });
+  Frame = dynamic(() => import('@craftjs/core').then((mod) => mod.Frame), {
+    ssr: false,
+    suspense: true,
+  });
+  Element = dynamic(() => import('@craftjs/core').then((mod) => mod.Element), {
+    ssr: false,
+    suspense: true,
+  });
+  SaveButton = dynamic(() => import('../components/SaveButton').then((mod) => mod.SaveButton), {
+    ssr: false,
+    suspense: true,
+  });
 }
 
 export default function Dashboard() {
@@ -81,21 +93,23 @@ export default function Dashboard() {
   return (
     <div>
       <SaveButton onSave={handleSave} />
-      <Editor resolver={resolver} onNodesChange={(query) => {
-        try {
-          setContent(JSON.parse(query.serialize()));
-        } catch (e) {
-          console.error('Failed to parse nodes', e);
-        }
-      }}>
-        <Frame data={hasContent ? content : undefined}>
-          {!hasContent && (
-            <Element is={Container} padding="40px" canvas>
-              <Text text="Welcome" fontSize="24px" />
-            </Element>
-          )}
-        </Frame>
-      </Editor>
+      <Suspense fallback={null}>
+        <Editor resolver={resolver} onNodesChange={(query) => {
+          try {
+            setContent(JSON.parse(query.serialize()));
+          } catch (e) {
+            console.error('Failed to parse nodes', e);
+          }
+        }}>
+          <Frame data={hasContent ? content : undefined}>
+            {!hasContent && (
+              <Element is={Container} padding="40px" canvas>
+                <Text text="Welcome" fontSize="24px" />
+              </Element>
+            )}
+          </Frame>
+        </Editor>
+      </Suspense>
     </div>
   );
 }

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import { Container } from '../components/Container';
 import { Text } from '../components/Text';
@@ -7,9 +7,18 @@ import { useCraftDisabled } from '../lib/useCraftDisabled';
 
 const resolver = { Container, Text };
 
-const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), { ssr: false });
-const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), { ssr: false });
-const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), { ssr: false });
+const Editor = dynamic(() => import('@craftjs/core').then(mod => mod.Editor), {
+  ssr: false,
+  suspense: true,
+});
+const Frame = dynamic(() => import('@craftjs/core').then(mod => mod.Frame), {
+  ssr: false,
+  suspense: true,
+});
+const Element = dynamic(() => import('@craftjs/core').then(mod => mod.Element), {
+  ssr: false,
+  suspense: true,
+});
 
 export default function Home({ page }) {
   const craftDisabled = useCraftDisabled();
@@ -32,15 +41,17 @@ export default function Home({ page }) {
   const hasContent = isValidContent(page.content, resolver);
 
   return (
-    <Editor resolver={resolver} enabled={!craftDisabled}>
-      <Frame data={hasContent ? page.content : undefined}>
-        {!hasContent && (
-          <Element is={Container} padding="40px" canvas>
-            <Text text="Welcome to the frontend" fontSize="24px" />
-          </Element>
-        )}
-      </Frame>
-    </Editor>
+    <Suspense fallback={null}>
+      <Editor resolver={resolver} enabled={!craftDisabled}>
+        <Frame data={hasContent ? page.content : undefined}>
+          {!hasContent && (
+            <Element is={Container} padding="40px" canvas>
+              <Text text="Welcome to the frontend" fontSize="24px" />
+            </Element>
+          )}
+        </Frame>
+      </Editor>
+    </Suspense>
   );
 }
 


### PR DESCRIPTION
## Summary
- import Suspense in Craft.js enabled pages
- load Craft.js components with `suspense: true`
- wrap editors in `<Suspense>` so Craft.js components mount properly

## Testing
- `npm test` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_6870a1139a44832881cc0f7ec7980a17