### PR TITLE
Fix permission setup for appointments and orders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .next/
 .tmp/
 db-data/
+unlocked-dashboard/

--- a/backend/src/api/appointment/controllers/appointment.js
+++ b/backend/src/api/appointment/controllers/appointment.js
@@ -1,0 +1,4 @@
+'use strict';
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::appointment.appointment');

--- a/backend/src/api/appointment/routes/appointment.js
+++ b/backend/src/api/appointment/routes/appointment.js
@@ -1,0 +1,36 @@
+'use strict';
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/appointments',
+      handler: 'appointment.find',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'GET',
+      path: '/appointments/:id',
+      handler: 'appointment.findOne',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'POST',
+      path: '/appointments',
+      handler: 'appointment.create',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'PUT',
+      path: '/appointments/:id',
+      handler: 'appointment.update',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'DELETE',
+      path: '/appointments/:id',
+      handler: 'appointment.delete',
+      config: { policies: [], middlewares: [] },
+    },
+  ],
+};

--- a/backend/src/api/appointment/services/appointment.js
+++ b/backend/src/api/appointment/services/appointment.js
@@ -1,0 +1,4 @@
+'use strict';
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::appointment.appointment');

--- a/backend/src/api/order/controllers/order.js
+++ b/backend/src/api/order/controllers/order.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const { createCoreController } = require('@strapi/strapi').factories;
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 
-module.exports = {
+module.exports = createCoreController('api::order.order', ({ strapi }) => ({
   async webhook(ctx) {
     const sig = ctx.request.headers['stripe-signature'];
     let event;
@@ -28,4 +29,4 @@ module.exports = {
 
     ctx.body = { received: true };
   },
-};
+}));

--- a/backend/src/api/order/routes/order.js
+++ b/backend/src/api/order/routes/order.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  routes: [
+    {
+      method: 'GET',
+      path: '/orders',
+      handler: 'order.find',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'GET',
+      path: '/orders/:id',
+      handler: 'order.findOne',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'POST',
+      path: '/orders',
+      handler: 'order.create',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'PUT',
+      path: '/orders/:id',
+      handler: 'order.update',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'DELETE',
+      path: '/orders/:id',
+      handler: 'order.delete',
+      config: { policies: [], middlewares: [] },
+    },
+    {
+      method: 'POST',
+      path: '/orders/webhook',
+      handler: 'order.webhook',
+      config: { auth: false },
+    },
+  ],
+};

--- a/backend/src/api/order/services/order.js
+++ b/backend/src/api/order/services/order.js
@@ -1,0 +1,4 @@
+'use strict';
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::order.order');


### PR DESCRIPTION
## Summary
- add missing Strapi controllers, routes and services for Appointment
- add missing routes and service for Order and extend controller via `createCoreController`
- ignore unused nested folder

These updates ensure actions like `api::appointment.appointment.create` and `api::order.order.create` exist so role permissions register without warnings.

## Testing
- `npm install` in backend
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6870cbc4a1ec8328b87bcf20c7ef6aea