### PR TITLE
Add Craft.js node type validation

### DIFF
--- a/frontend/scripts/check-node-types.js
+++ b/frontend/scripts/check-node-types.js
@@ -23,6 +23,52 @@ function listNodeTypes(tree) {
   return Array.from(seen);
 }
 
+// Known components from the frontend resolver
+const allowed = new Set([
+  'Container',
+  'Text',
+  'a',
+  'article',
+  'button',
+  'circle',
+  'div',
+  'em',
+  'footer',
+  'form',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'header',
+  'hr',
+  'img',
+  'input',
+  'label',
+  'li',
+  'main',
+  'nav',
+  'option',
+  'p',
+  'path',
+  'rect',
+  'section',
+  'select',
+  'span',
+  'strong',
+  'svg',
+  'table',
+  'tbody',
+  'td',
+  'text',
+  'textarea',
+  'th',
+  'thead',
+  'tr',
+  'ul'
+]);
+
 (async () => {
   try {
     const res = await fetch(url);
@@ -33,8 +79,16 @@ function listNodeTypes(tree) {
       const content = page.attributes?.content;
       if (content) listNodeTypes(content).forEach((t) => types.add(t));
     }
-    console.log('Craft node types found:', Array.from(types).join(', '));
+    const found = Array.from(types);
+    console.log('Craft node types found:', found.join(', '));
+    const unknown = found.filter((t) => !allowed.has(t));
+    if (unknown.length) {
+      console.error('Unknown Craft node types:', unknown.join(', '));
+      console.error('Add these components to the resolver before <Editor> mounts.');
+      process.exitCode = 1;
+    }
   } catch (err) {
     console.warn('Failed to fetch page data:', err.message);
+    process.exitCode = 1;
   }
 })();

--- a/scripts/setup_ubuntu_hyperv.sh
+++ b/scripts/setup_ubuntu_hyperv.sh
@@ -87,6 +87,14 @@ if ! grep -q 'TRANSFER_TOKEN_SALT:' docker-compose.yml; then
     sed -i '/API_TOKEN_SALT:/a\      TRANSFER_TOKEN_SALT: ${TRANSFER_TOKEN_SALT}' docker-compose.yml
 fi
 
+# Check Craft.js node types so missing components are caught early
+if command -v node &>/dev/null; then
+    echo "Validating Craft.js components in Strapi pages..."
+    if ! node frontend/scripts/check-node-types.js; then
+        echo "Craft.js component validation failed. See docs/craft_resolver_error.md for details." >&2
+    fi
+fi
+
 # Final message with instructions to start the stack
 echo
 echo "Setup complete! Review the .env file then launch the containers with:"


### PR DESCRIPTION
## Summary
- check saved Craft.js node types from Strapi
- fail if any component isn't part of the resolver
- run the validation from the setup script

## Testing
- `node frontend/scripts/check-node-types.js && echo ok || echo fail`
- `bash -n scripts/setup_ubuntu_hyperv.sh`

------
https://chatgpt.com/codex/tasks/task_b_6870dbf172a88328a145b1d758be9516