### PR TITLE
Fix Next.js Craft node type check

### DIFF
--- a/frontend/scripts/check-node-types.js
+++ b/frontend/scripts/check-node-types.js
@@ -89,6 +89,8 @@ const allowed = new Set([
     }
   } catch (err) {
     console.warn('Failed to fetch page data:', err.message);
-    process.exitCode = 1;
+    // Don't fail the build if the backend isn't reachable. Craft node type
+    // validation is best-effort and should not stop dev or CI environments.
+    process.exitCode = 0;
   }
 })();


### PR DESCRIPTION
## Summary
- avoid failing `npm run dev` when Strapi backend is unavailable

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_6870e1fadff48328a747a69f444631fe