### PR TITLE
Add DB reset helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ repo-root/
     ```
 5. To disable the Craft.js editor on the frontend, set `NEXT_PUBLIC_DISABLE_CRAFTJS=true` in `.env`.
 
+### Resetting the development database
+
+If Strapi migrations get stuck or you simply want a clean database, run the helper
+script:
+
+```bash
+scripts/reset_db_dev.sh
+```
+
+It drops all tables from the `strapi` Postgres database and recreates the `public`
+schema so the backend starts with a fresh state the next time you run
+`docker compose up`.
+
 ### Strapi v5 layout
 
 The backend now uses **Strapi v5** with a component‑driven architecture:

--- a/scripts/reset_db_dev.sh
+++ b/scripts/reset_db_dev.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Drop all tables in the development database
+# This is useful when Strapi migrations fail and you want to start over
+
+# Ensure docker compose is available
+if ! command -v docker &>/dev/null; then
+  echo "Docker is not installed" >&2
+  exit 1
+fi
+
+if docker compose version >/dev/null 2>&1; then
+  DC="docker compose"
+else
+  DC="docker-compose"
+fi
+
+$DC exec -T db psql -U strapi -d strapi -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+
+echo "Database schema reset."


### PR DESCRIPTION
## Summary
- add script for wiping Postgres tables in dev
- document how to use the script in README

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_6870ec2f1c0c8328a9c1e0a26af12090