### PR TITLE
Fix Strapi build memory issue

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 RUN npm install --production
 COPY . .
+# Increase Node's memory limit to prevent build failures
+ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN npm run build
 ENV NODE_ENV=production
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- increase Node memory limit when building the Strapi backend

## Testing
- `npm test` (fails: jest not found)
- `npm test` in `frontend` (fails: jest not found)

------
https://chatgpt.com/codex/tasks/task_b_6870f7d350bc8328b7f8e84e7882e4b9