### PR TITLE
Fix .env placeholders in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ repo-root/
 
 ## Development
 
-1. Copy `.env.example` to `.env` and adjust values as needed (particularly `APP_KEYS`, `ADMIN_JWT_SECRET`, `API_TOKEN_SALT`, `TRANSFER_TOKEN_SALT`, `ENCRYPTION_KEY` and `JWT_SECRET`).
+1. Copy `.env.example` to `.env` and replace **all** secrets that start with `changeme` or `change_me`.
+   Strapi refuses to start if these placeholders remain.
    If you plan to access the frontend from another machine on your network, set
    `NEXT_PUBLIC_BACKEND_URL` and `FRONTEND_URL` to the host's reachable IP (e.g. `http://192.168.2.20:3000`).
    These variables are now passed through Docker Compose so CORS works when
@@ -189,6 +190,7 @@ cd unlocked-dashboard
 
 # Copy environment variables
 cp .env.example .env
+# Replace all "changeme" values in .env with your own secrets
 
 # Start services (dependencies will be installed automatically)
 docker compose up --build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       DATABASE_USERNAME: strapi
       DATABASE_PASSWORD: strapi
       DATABASE_SSL: 'false'
-      APP_KEYS: change_me
-      ADMIN_JWT_SECRET: changeme
+      APP_KEYS: ${APP_KEYS}
+      ADMIN_JWT_SECRET: ${ADMIN_JWT_SECRET}
       JWT_SECRET: ${JWT_SECRET}
       API_TOKEN_SALT: KUNIpgntw/t3kgRAQfCN0w==
       TRANSFER_TOKEN_SALT: ${TRANSFER_TOKEN_SALT}


### PR DESCRIPTION
## Summary
- reference APP_KEYS and ADMIN_JWT_SECRET from `.env`
- clarify README instructions about replacing `changeme` values

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`
- `npm audit` in `frontend`
- `npm audit` in `backend`

------
https://chatgpt.com/codex/tasks/task_b_68712cee7974832887beb1eef21ebfbf