### PR TITLE
Fix next.js config for Strapi v5

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -29,10 +29,8 @@ const nextConfig = {
     FRONTEND_URL: process.env.FRONTEND_URL,
     NEXT_PUBLIC_DISABLE_CRAFTJS: process.env.NEXT_PUBLIC_DISABLE_CRAFTJS,
   },
-  experimental: {
-    // Include origins from the environment variable and automatically
-    // detected local network IPs to avoid cross-origin warnings.
-    allowedDevOrigins: Array.from(new Set([...envOrigins, ...getLocalOrigins()])),
-  },
+  // Include origins from the environment variable and automatically
+  // detected local network IPs to avoid cross-origin warnings.
+  allowedDevOrigins: Array.from(new Set([...envOrigins, ...getLocalOrigins()])),
 };
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- update `next.config.js` to place `allowedDevOrigins` at the top level

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68712d3f8f90832889c489264d89e786