### PR TITLE
Fix APP_KEYS generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ repo-root/
 
 1. Copy `.env.example` to `.env` and replace **all** secrets that start with `changeme` or `change_me`.
    Strapi refuses to start if these placeholders remain.
+   `start-dev.sh` now generates `APP_KEYS` automatically when missing, but you
+   should still review the other secrets.
    If you plan to access the frontend from another machine on your network, set
    `NEXT_PUBLIC_BACKEND_URL` and `FRONTEND_URL` to the host's reachable IP (e.g. `http://192.168.2.20:3000`).
    These variables are now passed through Docker Compose so CORS works when

--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env sh
 set -e
 
-# Verify required secrets are set and not using placeholder values
-required_vars="APP_KEYS ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT"
+# Generate APP_KEYS if unset or using a placeholder value
+if [ -z "${APP_KEYS:-}" ] || printf '%s' "$APP_KEYS" | grep -Eq '^changeme|^change_me'; then
+  APP_KEYS=$(node -e "console.log(Array.from({length:4}, () => require('crypto').randomBytes(16).toString('hex')).join(','))")
+  export APP_KEYS
+  echo "Generated APP_KEYS for development"
+fi
+
+# Verify remaining required secrets are set and not using placeholder values
+required_vars="ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT"
 
 for var in $required_vars; do
   value=$(eval "printf '%s' \"\${$var}\"")


### PR DESCRIPTION
## Summary
- generate APP_KEYS automatically in `start-dev.sh`
- document the new behaviour in the README

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_687164684c8c832883d3b18609ddf5f4