### PR TITLE
Fix APP_KEYS generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ repo-root/
 
 1. Copy `.env.example` to `.env` and replace **all** secrets that start with `changeme` or `change_me`.
    Strapi refuses to start if these placeholders remain.
+   `start-dev.sh` now generates `APP_KEYS`, `ADMIN_JWT_SECRET`, `JWT_SECRET`,
+   `API_TOKEN_SALT` and `TRANSFER_TOKEN_SALT` automatically when they are
+   missing, but you should still review the other secrets.
    If you plan to access the frontend from another machine on your network, set
    `NEXT_PUBLIC_BACKEND_URL` and `FRONTEND_URL` to the host's reachable IP (e.g. `http://192.168.2.20:3000`).
    These variables are now passed through Docker Compose so CORS works when

--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env sh
 set -e
 
-# Verify required secrets are set and not using placeholder values
-required_vars="APP_KEYS ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT"
 
-for var in $required_vars; do
-  value=$(eval "printf '%s' \"\${$var}\"")
-  case "$value" in
-    ""|changeme*|change_me*)
-      echo "Error: environment variable $var is not set or uses a placeholder value." >&2
-      echo "Edit your .env file to provide real secrets before starting Strapi." >&2
-      exit 1
-      ;;
-  esac
+# Helper to generate a random secret if missing or placeholder
+generate_secret() {
+  var_name=$1
+  current=$(eval "printf '%s' \"\${$var_name}\"")
+  if [ -z "${current}" ] || printf '%s' "$current" | grep -Eq '^changeme|^change_me'; then
+    case $var_name in
+      APP_KEYS)
+        new_value=$(node -e "console.log(Array.from({length:4}, () => require('crypto').randomBytes(16).toString('hex')).join(','))")
+        ;;
+      *)
+        new_value=$(node -e "console.log(require('crypto').randomBytes(32).toString('hex'))")
+        ;;
+    esac
+    export $var_name="$new_value"
+    echo "Generated $var_name for development"
+  fi
+}
+
+# Generate required secrets if missing
+for var in APP_KEYS ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SALT; do
+  generate_secret "$var"
 done
 
 # Launch Strapi in develop mode with debug logging


### PR DESCRIPTION
## Summary
- generate APP_KEYS, ADMIN_JWT_SECRET, JWT_SECRET, API_TOKEN_SALT and TRANSFER_TOKEN_SALT automatically in `start-dev.sh`
- document the new behaviour in the README

## Testing
- `npm test` in `backend` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_687164684c8c832883d3b18609ddf5f4