### PR TITLE
Allow optional DB reset on backend start

### DIFF
--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env sh
 set -e
 
+# Optionally reset the Postgres database if RESET_DB=true
+if [ "${RESET_DB:-false}" = "true" ]; then
+  echo "Resetting Postgres database..."
+  if ! command -v psql >/dev/null 2>&1; then
+    if command -v apk >/dev/null 2>&1; then
+      apk add --no-cache postgresql-client
+    else
+      apt-get update && apt-get install -y postgresql-client
+    fi
+  fi
+  PGPASSWORD="${DATABASE_PASSWORD:-strapi}" psql -h "${DATABASE_HOST:-db}" \
+    -U "${DATABASE_USERNAME:-strapi}" -d "${DATABASE_NAME:-strapi}" \
+    -c "DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;"
+fi
+
 
 # Generate APP_KEYS if unset or using a placeholder value
 if [ -z "${APP_KEYS:-}" ] || printf '%s' "$APP_KEYS" | grep -Eq '^changeme|^change_me'; then


### PR DESCRIPTION
## Summary
- add a RESET_DB flag to backend/start-dev.sh so the Postgres schema can be wiped before Strapi boots

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_687170e9c0648328898b366a17410910