### PR TITLE
Fix better-sqlite3 build mismatch

### DIFF
--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -48,5 +48,11 @@ for var in APP_KEYS ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SA
   generate_secret "$var"
 done
 
+# Rebuild better-sqlite3 if it was compiled for a different Node version
+if ! node -e "require('better-sqlite3')" >/dev/null 2>&1; then
+  echo "Rebuilding better-sqlite3 for Node $(node -v)..."
+  npm rebuild better-sqlite3
+fi
+
 # Launch Strapi in develop mode with debug logging
 exec npx strapi develop --debug


### PR DESCRIPTION
## Summary
- rebuild `better-sqlite3` automatically if compiled for the wrong Node version

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_6871e284aad083289d9439ac8dcb37b5