### PR TITLE
Update backend dev script

### DIFF
--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -48,10 +48,16 @@ for var in APP_KEYS ADMIN_JWT_SECRET JWT_SECRET API_TOKEN_SALT TRANSFER_TOKEN_SA
   generate_secret "$var"
 done
 
-# Rebuild better-sqlite3 if it was compiled for a different Node version
+# Ensure dependencies are installed
+if [ ! -d node_modules ]; then
+  echo "Installing backend dependencies..."
+  npm install
+fi
+
+# Rebuild better-sqlite3 if missing or compiled for a different Node version
 if ! node -e "require('better-sqlite3')" >/dev/null 2>&1; then
   echo "Rebuilding better-sqlite3 for Node $(node -v)..."
-  npm rebuild better-sqlite3
+  npm rebuild better-sqlite3 || npm install better-sqlite3
 fi
 
 # Launch Strapi in develop mode with debug logging


### PR DESCRIPTION
## Summary
- ensure dependencies are installed when starting the backend
- fallback to install better-sqlite3 if rebuild fails

## Testing
- `npm test --prefix backend`
- `npm test --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_b_6871ebbae6b883289a2d7dc6b73dc6f7