### PR TITLE
Ensure dev scripts enforce Node.js 20

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "develop": "strapi develop",
+    "develop": "sh ./start-dev.sh",
     "start": "strapi start",
     "build": "strapi build",
     "test": "jest"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "node ./scripts/check-node-types.js && NODE_OPTIONS=\"--inspect\" next dev",
+    "dev": "sh ./start-dev.sh",
     "check:types": "node ./scripts/check-node-types.js",
     "build": "next build",
     "start": "next start",

--- a/frontend/start-dev.sh
+++ b/frontend/start-dev.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env sh
+set -e
+
+# Ensure the correct Node.js version is used
+required_major=20
+current_major=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+if [ "$current_major" -ne "$required_major" ]; then
+  # Attempt to switch using nvm if available
+  if [ -z "$NVM_DIR" ] && [ -s "$HOME/.nvm/nvm.sh" ]; then
+    . "$HOME/.nvm/nvm.sh"
+    current_major=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+  fi
+  if command -v nvm >/dev/null 2>&1; then
+    echo "Switching to Node.js $required_major via nvm"
+    nvm install $required_major >/dev/null
+    nvm use $required_major >/dev/null
+    current_major=$(node -v 2>/dev/null | sed 's/^v\([0-9]*\).*/\1/')
+  fi
+  if [ "$current_major" -ne "$required_major" ]; then
+    echo "Node.js $required_major.x is required, found $(node -v)" >&2
+    exit 1
+  fi
+fi
+
+# Validate Craft.js node types
+node ./scripts/check-node-types.js
+
+# Start Next.js in dev mode
+NODE_OPTIONS="--inspect" next dev


### PR DESCRIPTION
## Summary
- update backend `npm run develop` to use `start-dev.sh`
- add frontend `start-dev.sh` with a Node 20 check
- run frontend dev via the new script

## Testing
- `cd backend && npm test`
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_b_6872142191088328b441f3db3808efae