### PR TITLE
Fix Strapi module error by adding dependency

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@strapi/plugin-users-permissions": "^5.18.0",
     "@strapi/strapi": "^5.18.0",
+    "better-sqlite3": "^12.2.0",
     "pg": "^8.16.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",


### PR DESCRIPTION
## Summary
- install `better-sqlite3` so local Strapi works when using the default SQLite database

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68722b65a02c8328a5af528a9fd345ca