### PR TITLE
Fix Next.js build OOM

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "develop": "sh ./start-dev.sh",
     "start": "strapi start",
-    "build": "strapi build",
+    "build": "NODE_OPTIONS=--max_old_space_size=4096 strapi build",
     "test": "jest"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "sh ./start-dev.sh",
     "check:types": "node ./scripts/check-node-types.js",
-    "build": "next build",
+    "build": "NODE_OPTIONS=--max_old_space_size=4096 next build",
     "start": "next start",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- increase memory limit in `next build` by setting NODE_OPTIONS
- do the same for Strapi build script

## Testing
- `npm test` in `frontend`
- `npm run build` in `frontend`
- `npm test` in `backend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_b_687238e8aa9083289878119707760d9d