### PR TITLE
Automate dev script setup

### DIFF
--- a/frontend/start-dev.sh
+++ b/frontend/start-dev.sh
@@ -25,5 +25,11 @@ fi
 # Validate Craft.js node types
 node ./scripts/check-node-types.js
 
+# Install dependencies if missing
+if [ ! -d node_modules ]; then
+  echo "Installing frontend dependencies..."
+  npm install
+fi
+
 # Start Next.js in dev mode
 NODE_OPTIONS="--inspect" next dev


### PR DESCRIPTION
## Summary
- auto-generate all secrets in setup script
- install dependencies in `frontend/start-dev.sh`

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_6872485ebbb88328a9fb0c9e6170fb32