### PR TITLE
Align docs with Strapi v5 backend

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -12,7 +12,7 @@ This guide explains **how to upgrade the `nvdigitalsolutions/unlocked-dashboard`
 It assumes:
 
 * **Frontend:** Next.js 13+ (Pages Router)
-* **Backend:** Strapi v4.x running at `BACKEND_URL`
+* **Backend:** Strapi v5.x running at `BACKEND_URL`
 * **Node ≥ 20** and **Yarn ≥ 3**
 
 ---


### PR DESCRIPTION
## Summary
- fix docs/upgrade.md to reference Strapi v5 instead of v4

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_68724a7740148328a5949ef3b8283f8b