### PR TITLE
Use npm ci for stable installs

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm install --production
+# Install dependencies using the lockfile to avoid peer resolution issues
+RUN npm ci --omit=dev --legacy-peer-deps
 COPY . .
 # Increase Node's memory limit to prevent build failures
 ENV NODE_OPTIONS=--max_old_space_size=4096

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,11 +9,11 @@ ARG ALLOWED_DEV_ORIGIN=http://localhost:3000
 ENV ALLOWED_DEV_ORIGIN=$ALLOWED_DEV_ORIGIN
 
 COPY package*.json ./
-# Install all dependencies so the build step has access to dev packages
-RUN npm install
+# Install dependencies using the lockfile for reproducible builds
+RUN npm ci
 COPY . .
 RUN npm run build
 
 # Remove development dependencies to keep the image slim
-RUN npm prune --production
+RUN npm prune --omit=dev
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- avoid peer dependency conflicts by installing with `npm ci`
- prune dev deps more explicitly in Dockerfiles

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_6872544a7ad88328bb69837afca8bc58