### PR TITLE
Fix dev dependency install flags

### DIFF
--- a/backend/start-dev.sh
+++ b/backend/start-dev.sh
@@ -73,7 +73,7 @@ done
 # Ensure dependencies are installed
 if [ ! -d node_modules ]; then
   echo "Installing backend dependencies..."
-  npm install
+  npm install --legacy-peer-deps
 fi
 
 # Rebuild better-sqlite3 if missing or compiled for a different Node version

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./backend:/app
       - backend-node-modules:/app/node_modules
-    command: sh -c "npm install && ./start-dev.sh"
+    command: sh -c "npm install --legacy-peer-deps && ./start-dev.sh"
     environment:
       DATABASE_CLIENT: postgres
       DATABASE_HOST: db
@@ -44,7 +44,7 @@ services:
       - frontend-node-modules:/app/node_modules
     # Install dependencies on the first run because the node_modules
     # volume overrides the image's files.
-    command: sh -c "npm install && npm run dev"
+    command: sh -c "npm install --legacy-peer-deps && npm run dev"
     environment:
       BACKEND_URL: http://backend:1337
       NEXT_PUBLIC_BACKEND_URL: ${NEXT_PUBLIC_BACKEND_URL}


### PR DESCRIPTION
## Summary
- ensure backend dev script installs with `--legacy-peer-deps`
- install with `--legacy-peer-deps` in docker-compose for both services

## Testing
- `npm test` in `backend`
- `npm test` in `frontend`


------
https://chatgpt.com/codex/tasks/task_b_687282bd72b88328bc77248af8f40e07