### PR TITLE
Fix Docker build for backend

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,12 @@
 FROM node:20-alpine
 WORKDIR /app
 COPY package.json package-lock.json* ./
-# Install dependencies using the lockfile to avoid peer resolution issues
-RUN npm ci --omit=dev --legacy-peer-deps
+# Install dependencies including dev packages to build Strapi's admin
+RUN npm ci --legacy-peer-deps
 COPY . .
 # Increase Node's memory limit to prevent build failures
 ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN npm run build
+RUN npm prune --omit=dev
 ENV NODE_ENV=production
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- install dev deps in backend Dockerfile so build succeeds
- prune dev deps after admin build

## Testing
- `npm -C backend test`
- `npm -C frontend test`
- `npm -C backend run build`
- `npm -C frontend run build`


------
https://chatgpt.com/codex/tasks/task_b_6872856f70b4832881f4513a3a1c366c